### PR TITLE
Adding a patch that improves the as-wasi::readAll function speed.

### DIFF
--- a/assemblyscript/package.json
+++ b/assemblyscript/package.json
@@ -7,7 +7,8 @@
     "asbuild:optimized": "asc examples/object-classification.ts --runtime stub --use abort=examples/object-classification/wasi_abort --target release",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "demo": "npm run asbuild && ./demo.sh",
-    "nn": "./wasmtime run build/optimized.wasm --dir build"
+    "nn": "./wasmtime run build/optimized.wasm --dir build",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
     "as-wasi": "^0.4.4"
   },
   "devDependencies": {
-    "assemblyscript": "^0.18.9"
+    "assemblyscript": "^0.18.9",
+    "patch-package": "^6.4.7"
   }
 }

--- a/assemblyscript/patches/as-wasi+0.4.4.patch
+++ b/assemblyscript/patches/as-wasi+0.4.4.patch
@@ -1,0 +1,49 @@
+diff --git a/node_modules/as-wasi/assembly/as-wasi.ts b/node_modules/as-wasi/assembly/as-wasi.ts
+index 87de05f..919d3cf 100644
+--- a/node_modules/as-wasi/assembly/as-wasi.ts
++++ b/node_modules/as-wasi/assembly/as-wasi.ts
+@@ -377,29 +377,26 @@ export class Descriptor {
+    */
+   readAll(
+     data: u8[] = [],
+-    chunk_size: usize = 4096
+   ): u8[] | null {
+-    let data_partial_len = chunk_size;
+-    let data_partial = changetype<usize>(new ArrayBuffer(data_partial_len as aisize));
+     let iov = memory.data(16);
+-    store<u32>(iov, data_partial, 0);
+-    store<u32>(iov, data_partial_len, sizeof<usize>());
+     let read_ptr = memory.data(8);
+-    let read: usize = 0;
+     let rawfd = this.rawfd;
+-    while (true) {
+-      if (fd_read(rawfd, iov, 1, read_ptr) !== errno.SUCCESS) {
+-        return null;
+-      }
+-      read = load<usize>(read_ptr);
+-      if (read <= 0) {
+-        break;
+-      }
+-      for (let i: usize = 0; i < read; i++) {
+-        data.push(load<u8>(data_partial + i));
+-      }
++    
++    // Find out the size of the file
++    let result = fd_seek(rawfd, 0, 2, read_ptr);
++    // Allocate the memory needed to copy the file's data
++    data = new Array<u8>(load<usize>(read_ptr) as aisize);
++    // Move the pointer back to the beginning of the file
++    result = fd_seek(rawfd, 0, 0, read_ptr);
++
++    store<u32>(iov, data.dataStart, 0);
++    store<u32>(iov, data.length, sizeof<usize>());
++
++    if (fd_read(rawfd, iov, 1, read_ptr) !== errno.SUCCESS) {
++      return null;
+     }
+-    if (read < 0) {
++    
++    if (load<usize>(read_ptr) < 0) {
+       return null;
+     }
+     return data;


### PR DESCRIPTION
Now the AssemblyScript example of wasi-nn is just as fast as the
rust version.