### PR TITLE
Changing getOutput bindings to require passing an array.

### DIFF
--- a/assemblyscript/assembly/as-wasi-nn.ts
+++ b/assemblyscript/assembly/as-wasi-nn.ts
@@ -81,7 +81,7 @@ export class ExecutionContext {
     // TODO once we have functions to get the output buffer size, we shouldn't need the user to pass in the buffer.
     // NOTE: If you get a NotEnoughMemory error, try upping the size of outputBuffer
     getOutput(index: u32, outputBuffer: Array<u8>): Tensor {
-        let maxBufferLength = outputBuffer.length; // TODO allow user to configure this
+        let maxBufferLength = outputBuffer.length;
         let bytesWritten: u32 = changetype<u32>(memory.data(4));
         let resultCode = wasi_ephemeral_nn.get_output(load<u32>(this.pointer), index,
             changetype<u32>(getArrayPtr(outputBuffer)),

--- a/assemblyscript/assembly/as-wasi-nn.ts
+++ b/assemblyscript/assembly/as-wasi-nn.ts
@@ -78,9 +78,10 @@ export class ExecutionContext {
         }
     }
 
-    getOutput(index: u32): Tensor {
-        let maxBufferLength = 4004; // TODO allow user to configure this
-        let outputBuffer = new Array<u8>(maxBufferLength).fill(0);
+    // TODO once we have functions to get the output buffer size, we shouldn't need the user to pass in the buffer.
+    // NOTE: If you get a NotEnoughMemory error, try upping the size of outputBuffer
+    getOutput(index: u32, outputBuffer: Array<u8>): Tensor {
+        let maxBufferLength = outputBuffer.length; // TODO allow user to configure this
         let bytesWritten: u32 = changetype<u32>(memory.data(4));
         let resultCode = wasi_ephemeral_nn.get_output(load<u32>(this.pointer), index,
             changetype<u32>(getArrayPtr(outputBuffer)),

--- a/assemblyscript/examples/object-classification.ts
+++ b/assemblyscript/examples/object-classification.ts
@@ -18,7 +18,7 @@ export function main(): i32 {
     Console.log("Running classification...");
     context.compute();
     let maxBufferLength = 4004; // Size of our output buffer
-    const output = context.getOutput(0, new Array<u8>(maxBufferLength).fill(0));
+    const output = context.getOutput(0, new Array<u8>(4004).fill(0));
 
     const results = sortResults(output, 5);
     Console.log("Top 5 results: ");

--- a/assemblyscript/examples/object-classification.ts
+++ b/assemblyscript/examples/object-classification.ts
@@ -17,7 +17,8 @@ export function main(): i32 {
 
     Console.log("Running classification...");
     context.compute();
-    const output = context.getOutput(0);
+    let maxBufferLength = 4004; // Size of our output buffer
+    const output = context.getOutput(0, new Array<u8>(maxBufferLength).fill(0));
 
     const results = sortResults(output, 5);
     Console.log("Top 5 results: ");


### PR DESCRIPTION
The user can now allocate the size of the array they want to use
for the output buffer. This will allow users to use different
buffer sizes based on their needs, and make it more obvious what
is going wrong if they run out of memory.