### PR TITLE
Updating the scripts and docs to install OpenVino

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ WebAssembly, and run it in a WebAssembly runtime that supports the [wasi-nn] pro
 [npmjs.com]: https://www.npmjs.com/package/wasi-nn
 [AssemblyScript README]: assemblyscript/README.md
 
-
 ### Examples
 
 This repository includes examples of using these bindings. See the [Rust example] and
-[AssemblyScript example] to walk through an end-to-end image classification using an AlexNet model.
-Run them with:
+[AssemblyScript example] to walk through an end-to-end image classification using an AlexNet model. Currently the example uses OpenVino as the backend. If you are running Ubuntu, you can simply run the script to install the supported version`.github/actions/install-openvino/install.sh`. Otherwise you'll need to visit the [Installation Guides] and follow the instructions for your OS. The version of OpenVino currently supported is openvino_2020.4.287.
+
+Once you have OpenVino installed, run them with:
  - `./build.sh rust` runs the [Rust example]
  - `./build.sh as` runs the [AssemblyScript example]
 
 [Rust example]: rust/examples/classification-example
 [AssemblyScript example]: assemblyscript/examples/object-classification.ts
-
+[Installation Guides]: https://docs.openvinotoolkit.org/latest/installation_guides.html
 
 ### Related Links
 
@@ -65,10 +65,11 @@ Run them with:
 - [wasi-nn]
 - [Wasmtime]
 - [AssemblyScript]
+- [OpenVino]
 
 [WASI]: https://github.com/WebAssembly/WASI
 [AssemblyScript]: https://www.assemblyscript.org/
-
+[OpenVino]: https://docs.openvinotoolkit.org/latest/index.html
 
 ### License
 

--- a/build.sh
+++ b/build.sh
@@ -1,41 +1,46 @@
 #!/bin/bash
 
 set -e
-if [ -z $1 ]; then
-    echo "Please specify as or rust to build"
+if [ ! -d "/opt/intel/openvino" ]; then
+    echo "Please install OpenVino"
+
 else
-    BUILD_TYPE=$1
-    WASI_NN_DIR=$(dirname "$0" | xargs dirname)
-    WASI_NN_DIR=$(realpath $WASI_NN_DIR)
-    source /opt/intel/openvino/bin/setupvars.sh
+    if [ -z $1 ]; then
+        echo "Please specify as or rust to build"
+    else
+        BUILD_TYPE=$1
+        WASI_NN_DIR=$(dirname "$0" | xargs dirname)
+        WASI_NN_DIR=$(realpath $WASI_NN_DIR)
+        source /opt/intel/openvino/bin/setupvars.sh
 
-    case $BUILD_TYPE in
-        as)
-        pushd $WASI_NN_DIR/assemblyscript
-            npm install
-            npm run demo
-        ;;
+        case $BUILD_TYPE in
+            as)
+            pushd $WASI_NN_DIR/assemblyscript
+                npm install
+                npm run demo
+            ;;
 
-        rust)
-            echo "The first argument: $1"
-            FIXTURE=https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtures/mobilenet
-            pushd $WASI_NN_DIR/rust/
-            cargo build --release --target=wasm32-wasi
-            mkdir -p $WASI_NN_DIR/rust/examples/classification-example/build
-            RUST_BUILD_DIR=$(realpath $WASI_NN_DIR/rust/examples/classification-example/build/)
-            cp -rn images $RUST_BUILD_DIR
-            pushd examples/classification-example
-            cargo build --release --target=wasm32-wasi
-            cp target/wasm32-wasi/release/wasi-nn-example.wasm $RUST_BUILD_DIR
-            pushd build
-            wget --no-clobber --directory-prefix=$RUST_BUILD_DIR $FIXTURE/mobilenet.bin
-            wget --no-clobber --directory-prefix=$RUST_BUILD_DIR $FIXTURE/mobilenet.xml
-            wasmtime run --mapdir fixture::$RUST_BUILD_DIR wasi-nn-example.wasm --wasi-modules=experimental-wasi-nn
-        ;;
-        *)
-            echo "Unknown build type $BUILD_TYPE"
-        ;;
-    esac
+            rust)
+                echo "The first argument: $1"
+                FIXTURE=https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtures/mobilenet
+                pushd $WASI_NN_DIR/rust/
+                cargo build --release --target=wasm32-wasi
+                mkdir -p $WASI_NN_DIR/rust/examples/classification-example/build
+                RUST_BUILD_DIR=$(realpath $WASI_NN_DIR/rust/examples/classification-example/build/)
+                cp -rn images $RUST_BUILD_DIR
+                pushd examples/classification-example
+                cargo build --release --target=wasm32-wasi
+                cp target/wasm32-wasi/release/wasi-nn-example.wasm $RUST_BUILD_DIR
+                pushd build
+                wget --no-clobber --directory-prefix=$RUST_BUILD_DIR $FIXTURE/mobilenet.bin
+                wget --no-clobber --directory-prefix=$RUST_BUILD_DIR $FIXTURE/mobilenet.xml
+                wasmtime run --mapdir fixture::$RUST_BUILD_DIR wasi-nn-example.wasm --wasi-modules=experimental-wasi-nn
+            ;;
+            *)
+                echo "Unknown build type $BUILD_TYPE"
+            ;;
+        esac
+
+    fi
 fi
-
 


### PR DESCRIPTION
Script will check that OpenVino is installed before
building the demos. And the documentaion tells you
what script to call to install the proper version
of OpenVino effortlessly (on Ubuntu).