### PR TITLE
Ignore files in their correct directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-assemblyscript/build
-assemblyscript/node_modules
-assemblyscript/package-lock.json
-assemblyscript/wasmtime
-rust/examples/classification-example/build
-rust/examples/classification-example/target
 wasmtime
-

--- a/assemblyscript/.gitignore
+++ b/assemblyscript/.gitignore
@@ -1,0 +1,4 @@
+build
+node_modules
+package-lock.json
+wasmtime

--- a/assemblyscript/.npmignore
+++ b/assemblyscript/.npmignore
@@ -1,0 +1,6 @@
+build
+node_modules
+package-lock.json
+wasmtime
+images
+docs

--- a/rust/examples/classification-example/.gitignore
+++ b/rust/examples/classification-example/.gitignore
@@ -1,0 +1,2 @@
+build
+target


### PR DESCRIPTION
Previously, a top-level `.gitignore` meant that ignored files in the language sub-directories (`assemblyscript` and `rust`) were still included in the packaged files. This drastically increased the size of the packages. By moving the ignored files down a level and adding an `.npmignore` for the AssemblyScript library, the packages can remain small.