### PR TITLE
Bump version to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ WebAssembly, and run it in a WebAssembly runtime that supports the [wasi-nn] pro
 
 ### Use
 
- - In Rust, download the [crate from crates.io][crates.io] by adding `wasi-nn = "0.3.0"` as a Cargo
+ - In Rust, download the [crate from crates.io][crates.io] by adding `wasi-nn = "0.4.0"` as a Cargo
    dependency; more information in the [Rust README].
  - In AssemblyScript, download the [package from npmjs.com][npmjs.com] by adding `"as-wasi-nn":
    "^0.3.0"` as an NPM dependency; more information in the [AssemblyScript README].

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasi-nn"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "thiserror",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "wasi-nn"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Bytecode Alliance Developers"]
 description = "High-level Rust bindings for wasi-nn"
 license = "Apache-2.0"
 categories = ["wasm", "computer-vision"]
 keywords = ["webassembly", "wasm", "neural-network"]
 repository = "https://github.com/bytecodealliance/wasi-nn"
+documentation = "https://docs.rs/wasi_nn"
 readme = "README.md"
 edition = "2018"
 publish = true

--- a/rust/README.md
+++ b/rust/README.md
@@ -16,21 +16,18 @@ functionality from WebAssembly.
 1. Depend on this crate in your `Cargo.toml`:
     ```toml
     [dependencies]
-    wasi-nn = "0.3.0"
+    wasi-nn = "0.4.0"
     ```
 
 2. Use the wasi-nn APIs in your application, for example:
     ```rust
     use wasi_nn;
-
-    unsafe {
-        wasi_nn::load(
-            &[&xml.into_bytes(), &weights],
-            wasi_nn::GRAPH_ENCODING_OPENVINO,
-            wasi_nn::EXECUTION_TARGET_CPU,
-        )
-        .unwrap()
-    }
+    let graph = GraphBuilder::new(GraphEncoding::TensorflowLite, ExecutionTarget::CPU)
+        .build_from_files([model_path])?;
+    let mut ctx = graph.init_execution_context()?;
+    ctx.set_input(0, TensorType::F32, &input_dims, &input_buffer)?;
+    ctx.compute()?;
+    let output_num_bytes = ctx.get_output(0, &mut output_buffer)?;
     ```
 
 3. Compile the application to WebAssembly:
@@ -38,7 +35,7 @@ functionality from WebAssembly.
     cargo build --target=wasm32-wasi
     ```
 
-4. Run the generated WebAssembly in a runtime supporting [wasi-nn], e.g. [Wasmtime].
+4. Run the generated WebAssembly in a runtime supporting [wasi-nn], e.g., [Wasmtime].
 
 [Wasmtime]: https://wasmtime.dev
 

--- a/rust/examples/classification-example/Cargo.toml
+++ b/rust/examples/classification-example/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasi-nn = { path = "../../", version = "0.3" }
+wasi-nn = { path = "../../", version = "0.4" }
 image2tensor = { path = "../../../image2tensor" }
 
 # This crate is built with the wasm32-wasi target, so it's separate


### PR DESCRIPTION
With #81 merged, which changes the API to a much higher-level, it seems appropriate to bump the version.