### PR TITLE
Bump Rust crate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ WebAssembly, and run it in a WebAssembly runtime that supports the [wasi-nn] pro
 
 ### Use
 
- - In Rust, download the [crate from crates.io][crates.io] by adding `wasi-nn = "0.5.0"` as a Cargo
+ - In Rust, download the [crate from crates.io][crates.io] by adding `wasi-nn = "0.6.0"` as a Cargo
    dependency; more information in the [Rust README].
  - In AssemblyScript, download the [package from npmjs.com][npmjs.com] by adding `"as-wasi-nn":
    "^0.3.0"` as an NPM dependency; more information in the [AssemblyScript README].

--- a/image2tensor/Cargo.lock
+++ b/image2tensor/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "image2tensor"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "image",
 ]

--- a/image2tensor/Cargo.toml
+++ b/image2tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image2tensor"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The Bytecode Alliance Developers"]
 description = "Image to tensor conversion"
 license = "Apache-2.0"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasi-nn"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "thiserror",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-nn"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Bytecode Alliance Developers"]
 description = "High-level Rust bindings for wasi-nn"
 license = "Apache-2.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -16,7 +16,7 @@ functionality from WebAssembly.
 1. Depend on this crate in your `Cargo.toml`:
     ```toml
     [dependencies]
-    wasi-nn = "0.5.0"
+    wasi-nn = "0.6.0"
     ```
 
 2. Use the wasi-nn APIs in your application, for example:

--- a/rust/examples/classification-example/Cargo.lock
+++ b/rust/examples/classification-example/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "image2tensor"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "image",
 ]
@@ -229,7 +229,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasi-nn"
-version = "0.3.0"
+version = "0.6.0"
 dependencies = [
  "thiserror",
 ]

--- a/rust/examples/classification-example/Cargo.toml
+++ b/rust/examples/classification-example/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasi-nn = { path = "../../", version = "0.5" }
+wasi-nn = { path = "../../" }
 image2tensor = { path = "../../../image2tensor" }
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/rust/examples/classification-example/src/main.rs
+++ b/rust/examples/classification-example/src/main.rs
@@ -25,7 +25,7 @@ pub fn main() {
         let filename: String = format!("{}{}{}", "fixture/images/", i, ".jpg");
         // Convert the image. If it fails just exit
         let tensor_data =
-            convert_image_to_bytes(&filename, 224, 224, TensorType::F32, ColorOrder::BGR)
+            convert_image_to_tensor_bytes(&filename, 224, 224, TensorType::F32, ColorOrder::BGR)
                 .or_else(|e| Err(e))
                 .unwrap();
 


### PR DESCRIPTION
Includes minor API changes:
 - new `convert_image_bytes_to_tensor_bytes` function in `image2tensor`
 - new 64-bit tensor types in `wasi-nn`