### PR TITLE
Update link to Installation Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once you have OpenVino installed, run them with:
 
 [Rust example]: rust/examples/classification-example
 [AssemblyScript example]: assemblyscript/examples/object-classification.ts
-[Installation Guides]: https://docs.openvinotoolkit.org/latest/installation_guides.html
+[Installation Guides]: https://docs.openvino.ai/2023.3/openvino_docs_install_guides_overview.html
 
 To run examples in WasmEdge, consult this article: [WasmEdge wasi-nn examples].
 


### PR DESCRIPTION
Installation Guides links to https://docs.openvinotoolkit.org/latest/installation_guides.html which redirects to https://docs.openvino.ai/2022.3/openvino_docs_install_guides_installing_openvino_linux.html (404).

Updating link to https://docs.openvino.ai/2023.3/openvino_docs_install_guides_overview.html